### PR TITLE
feat: create custom route class

### DIFF
--- a/src/routing.py
+++ b/src/routing.py
@@ -1,6 +1,27 @@
-from fastapi import routing
+import json
+import logging
+from http import HTTPStatus
+from typing import Any, Callable, Dict
+
+from fastapi import Request, Response, routing
+
+logger = logging.getLogger(__name__)
+
+Handler = Callable[[Dict[str, Any], Any], Dict[str, Any]]
+
+
+def default_endpoint(request: Request) -> Response:
+    logger.error(f"Executing default endpoint: {request.scope}")
+
+    status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+    media_type = "application/json"
+    content = json.dumps({"error": "Invalid endpoint execution"})
+    response = Response(status_code=status_code, media_type=media_type, content=content)
+
+    return response
 
 
 class APIRoute(routing.APIRoute):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, lambda_handler: Handler, *args, **kwargs):
+        super().__init__(endpoint=default_endpoint, *args, **kwargs)
+        self.lambda_handler = lambda_handler

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,10 +1,34 @@
+from http import HTTPStatus
 import unittest
 
-from fastapi import routing
-from routing import APIRoute
+import routing
+from fastapi import Response, Request
 
 
 class TestAPIRoute(unittest.TestCase):
-    def test_sam_instance_of_api_route(self):
-        api_route = APIRoute(path="/api", endpoint=lambda x: ...)
-        self.assertIsInstance(api_route, routing.APIRoute)
+    def test_default_endpoint(self):
+        with self.assertLogs(logger=routing.__name__, level="ERROR") as logs:
+            scope = {"type": "http"}
+            request = Request(scope)
+            response = routing.default_endpoint(request)
+
+        self.assertIsInstance(response, Response)
+        self.assertEqual(response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
+        self.assertEqual(response.media_type, "application/json")
+        self.assertEqual(response.body, b'{"error": "Invalid endpoint execution"}')
+
+        expected_logs = ["ERROR:routing:Executing default endpoint: {'type': 'http'}"]
+        self.assertEqual(logs.output, expected_logs)
+
+    def test_route(self):
+        def handler(event, context):
+            print(f"event: {event}\ncontext: {context}")
+            return {"statusCode": 200, "body": ""}
+
+        route = routing.APIRoute(path="/test", name="test", lambda_handler=handler)
+
+        self.assertEqual(route.path, "/test")
+        self.assertEqual(route.name, "test")
+        self.assertEqual(route.methods, {"GET"})
+        self.assertIsInstance(route.endpoint, routing.default_endpoint.__class__)
+        self.assertIsInstance(route.lambda_handler, handler.__class__)


### PR DESCRIPTION
### Contain
- [x] New feature
- [x] Tests

### Details
* Add custom route to extend FastAPI's APIRoute.
  * This is required once we need to override regular route execution due to different function signatures between Starlette's endpoints and SAM Lambda Function handlers.
