### PR TITLE
feat: instantiate object template inside SAM

### DIFF
--- a/src/adapter.py
+++ b/src/adapter.py
@@ -8,4 +8,4 @@ import cloudformation
 class SAM(FastAPI):
     def __init__(self, template: Optional[str] = None, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self._cloudformation = cloudformation.load(template)
+        self._cloudformation = cloudformation.Template(template)

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -11,22 +11,16 @@ class TestSAMAdapter(unittest.TestCase):
 
     def test_initialization_with_template(self):
         sam = SAM(f"{self.path_templates}/example1.yml")
-
-        self.assertIsNotNone(sam._cloudformation)
-        self.assertIsInstance(sam._cloudformation, dict)
-        self.assertIn("Resources", sam._cloudformation)
+        self.assertIsInstance(sam, SAM)
 
     def test_initialization_without_template(self):
         symlink = Path("template.yml")
         symlink.symlink_to("tests/fixtures/templates/example1.yml")
 
         sam = SAM()
-
         symlink.unlink()
 
-        self.assertIsNotNone(sam._cloudformation)
-        self.assertIsInstance(sam._cloudformation, dict)
-        self.assertIn("Resources", sam._cloudformation)
+        self.assertIsInstance(sam, SAM)
 
     def test_initialization_without_template_exception(self):
         with self.assertRaises(CFTemplateNotFound):


### PR DESCRIPTION
### Contain
- [x] New feature
- [ ] Bugfix
- [x] Tests
- [ ] Documentation
- [ ] Build/CI/CD
- [ ] Breaking changes
- [ ] Refactor
- [ ] Configuration changes
- [ ] Migrations

### Details
* change private attribute cloudformation initialization to receive an object Template instead of a dictionary 
