### PR TITLE
feat: change api route class to receive endpoint as a string path

### DIFF
--- a/src/routing.py
+++ b/src/routing.py
@@ -82,6 +82,7 @@ def import_handler(path: str) -> Handler:
 
 
 class APIRoute(routing.APIRoute):
-    def __init__(self, lambda_handler: Handler, *args, **kwargs):
-        super().__init__(endpoint=default_endpoint, *args, **kwargs)
-        self.lambda_handler = lambda_handler
+    def __init__(self, path: str, endpoint: str, *args, **kwargs):
+        handler_path = endpoint
+        handler_func = import_handler(handler_path)
+        super().__init__(path=path, endpoint=handler(handler_func), *args, **kwargs)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -46,17 +46,14 @@ class TestAPIRoute(unittest.TestCase):
         self.assertEqual(logs.output, expected_logs)
 
     def test_route(self):
-        def handler(event, context):
-            print(f"event: {event}\ncontext: {context}")
-            return {"statusCode": 200, "body": ""}
+        endpoint = "tests.fixtures.handlers.lambda_handler.handler"
 
-        route = routing.APIRoute(path="/test", name="test", lambda_handler=handler)
+        route = routing.APIRoute(path="/test", name="test", endpoint=endpoint)
 
         self.assertEqual(route.path, "/test")
         self.assertEqual(route.name, "test")
         self.assertEqual(route.methods, {"GET"})
-        self.assertIsInstance(route.endpoint, routing.default_endpoint.__class__)
-        self.assertIsInstance(route.lambda_handler, handler.__class__)
+        self.assertTrue(callable(route.endpoint))
 
 
 class TestImportHandler(unittest.TestCase):


### PR DESCRIPTION
### Contain
- [x] New feature
- [x] Tests

### Details
* Update APIRoute class to receive the endpoint argument as a string path.
  * The actual function is now imported by the import_handler helper function during instance initialization.
