### PR TITLE
refactor: change data structure for class CloudFormationTemplate properties

### DIFF
--- a/src/adapter.py
+++ b/src/adapter.py
@@ -12,10 +12,10 @@ class SAM:
         self.route_mapping()
 
     def route_mapping(self) -> None:
-        self.routes: Dict[str, Any] = {gateway["Id"]: dict() for gateway in self.template.gateways}
+        self.routes: Dict[str, Any] = {key: dict() for key in self.template.gateways.keys()}
         self.routes["ImplicitGateway"] = {}
 
-        for function in self.template.functions:
+        for function in self.template.functions.values():
             if "Events" not in function["Properties"]:
                 continue
 
@@ -25,7 +25,7 @@ class SAM:
 
             events = self.template.find_nodes(function["Properties"]["Events"], NodeType.API)
 
-            for event in events:
+            for event in events.values():
                 path = event["Properties"]["Path"]
                 method = event["Properties"]["Method"]
                 endpoint = {method: {"handler": handler_path}}

--- a/src/cloudformation.py
+++ b/src/cloudformation.py
@@ -65,13 +65,13 @@ class CloudformationTemplate:
         self.template = self.load(template_path)
 
     @property
-    def functions(self) -> List[Dict[str, Any]]:
+    def functions(self) -> Dict[str, Any]:
         if not hasattr(self, "_functions"):
             self._functions = self.find_nodes(self.template["Resources"], NodeType.LAMBDA)
         return self._functions
 
     @property
-    def gateways(self) -> List[Dict[str, Any]]:
+    def gateways(self) -> Dict[str, Any]:
         if not hasattr(self, "_gateways"):
             self._gateways = self.find_nodes(self.template["Resources"], NodeType.API_GATEWAY)
         return self._gateways
@@ -93,11 +93,11 @@ class CloudformationTemplate:
         with path.open() as fp:
             return yaml.load(fp, CFLoader)
 
-    def find_nodes(self, tree: Dict[str, Any], node_type: NodeType) -> List[Dict[str, Any]]:
-        nodes = []
+    def find_nodes(self, tree: Dict[str, Any], node_type: NodeType) -> Dict[str, Any]:
+        nodes = {}
 
         for key, node in tree.items():
             if node["Type"] == node_type.value:
-                nodes.append({"Id": key, **node})
+                nodes[key] = node
 
         return nodes

--- a/tests/test_cloudformation.py
+++ b/tests/test_cloudformation.py
@@ -78,19 +78,30 @@ class TestCloudFormation(unittest.TestCase):
 
 class TestTemplate(unittest.TestCase):
     def setUp(self):
-        self.function = {
-            "Id": "HelloWorldFunction",
-            "Type": "AWS::Serverless::Function",
-            "Properties": {
-                "CodeUri": "hello_world/",
-                "Handler": "app.lambda_handler",
-                "Runtime": "python3.11",
-                "Architectures": ["x86_64"],
-                "Events": {
-                    "HelloWorld": {
-                        "Type": "Api",
-                        "Properties": {"Path": "/hello", "Method": "get"},
-                    }
+        self.functions = {
+            "HelloWorldFunction": {
+                "Type": "AWS::Serverless::Function",
+                "Properties": {
+                    "CodeUri": "hello_world/",
+                    "Handler": "app.lambda_handler",
+                    "Runtime": "python3.11",
+                    "Architectures": ["x86_64"],
+                    "Events": {
+                        "HelloWorld": {
+                            "Type": "Api",
+                            "Properties": {"Path": "/hello", "Method": "get"},
+                        }
+                    },
+                },
+            }
+        }
+
+        self.gateways = {
+            "ApiGateway": {
+                "Type": "AWS::Serverless::Api",
+                "Properties": {
+                    "Name": "sam-api",
+                    "StageName": "v1",
                 },
             },
         }
@@ -121,31 +132,16 @@ class TestTemplate(unittest.TestCase):
     def test_list_functions(self):
         cloudformation = CloudformationTemplate(self.template_1)
 
-        expected_functions = [self.function]
-
-        self.assertEqual(cloudformation.functions, expected_functions)
+        self.assertEqual(cloudformation.functions, self.functions)
 
     def test_list_gateways(self):
         cloudformation = CloudformationTemplate("tests/fixtures/templates/example2.yml")
 
-        expected_gateways = [
-            {
-                "Id": "ApiGateway",
-                "Type": "AWS::Serverless::Api",
-                "Properties": {
-                    "Name": "sam-api",
-                    "StageName": "v1",
-                },
-            },
-        ]
-
-        self.assertEqual(cloudformation.gateways, expected_gateways)
+        self.assertEqual(cloudformation.gateways, self.gateways)
 
     def test_find_nodes(self):
         cloudformation = CloudformationTemplate("tests/fixtures/templates/example1.yml")
         tree = cloudformation.template
         nodes = cloudformation.find_nodes(tree["Resources"], cf.NodeType.LAMBDA)
 
-        expected_nodes = [self.function]
-
-        self.assertEqual(nodes, expected_nodes)
+        self.assertEqual(nodes, self.functions)


### PR DESCRIPTION
### Contain
- [x] Refactor
- [x] Tests
- [x] Breaking changes

### Details
* Update CloudformationTemplate class with the following changes:
  * Change data structure returned by `find_nodes` method to return a dictionary instead of a list.
  * Update `functions` and `gateways` properties type annotation, now they return a dictionary.
* Update SAM adapter class to properly use new data structure for `functions` and `gateways` properties of CloudFormation templates.
