### PR TITLE
fix: server list in openapi schema

### DIFF
--- a/faster_sam/openapi.py
+++ b/faster_sam/openapi.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, List
 
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
@@ -15,7 +15,11 @@ def custom_openapi(app: FastAPI, openapi_schema: Dict[str, Any]) -> Callable[[],
             summary=app.summary,
             description=app.description,
             routes=app.routes,
+            servers=app.servers,
         )
+
+        servers: List[Dict[str, Any]] = fastapi_schema.get("servers", [])
+        servers.extend(openapi_schema.get("servers", []))
 
         paths = {**fastapi_schema["paths"], **openapi_schema["paths"]}
 
@@ -44,7 +48,7 @@ def custom_openapi(app: FastAPI, openapi_schema: Dict[str, Any]) -> Callable[[],
         if examples:
             components["examples"] = examples
 
-        app.openapi_schema = {**openapi_schema, "paths": paths}
+        app.openapi_schema = {**openapi_schema, "servers": servers, "paths": paths}
         app.openapi_schema["components"] = components
 
         return app.openapi_schema

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 
 import yaml
@@ -14,12 +15,16 @@ class TestCustomOpenAPI(unittest.TestCase):
             cls.openapi_schema = yaml.safe_load(fp)
 
     def test_custom_openapi(self):
-        app = FastAPI()
+        server = {"url": "/test"}
+        app = FastAPI(servers=[server])
         app.openapi = custom_openapi(app, self.openapi_schema)
 
         openapi_schema = app.openapi()
 
-        self.assertEqual(openapi_schema, self.openapi_schema)
+        expected_schema = copy.deepcopy(self.openapi_schema)
+        expected_schema["servers"].insert(0, server)
+
+        self.assertEqual(openapi_schema, expected_schema)
 
     def test_register_route(self):
         examples = [{"bar": "Bar", "baz": 1}]


### PR DESCRIPTION
### Contain
- [x] Bugfix
- [x] Tests

### Details
* Update custom_openapi function responsible for generating openapi schema fixing the issue with the server list section when the root_path argument was set.
