### PR TITLE
fix: read the docs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,14 @@
 version: 2
 
 build:
-   os: ubuntu-22.04
-   tools:
-     python: "3.12"
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+python:
+  install:
+    - method: pip
+      path: .
 
 sphinx:
-   configuration: docs/conf.py
+  configuration: docs/conf.py


### PR DESCRIPTION
### Contain
- [x] Bugfix

### Details
* Update read the docs configuration file adding an entry to install the package before generating the docs.
