### PR TITLE
fix: error using upper to get environment variables

### DIFF
--- a/faster_sam/middlewares/lambda_authorizer.py
+++ b/faster_sam/middlewares/lambda_authorizer.py
@@ -39,7 +39,7 @@ class Credentials:
                 return None
 
         for attr in attrs:
-            setattr(self, attr.name, os.getenv(f"AWS_{attr.name.upper}"))
+            setattr(self, attr.name, os.getenv(f"AWS_{attr.name.upper()}"))
 
 
 class LambdaClient:


### PR DESCRIPTION
### Contain
- [x] New feature
- [ ] Bugfix
- [ ] Tests
- [ ] Documentation
- [ ] Build/CI/CD
- [ ] Breaking changes
- [ ] Refactor
- [ ] Configuration changes
- [ ] Migrations

### Details
* Fix error getting environment variable