### PR TITLE
fix: cases where return is null for sqs

### DIFF
--- a/faster_sam/lambda_event.py
+++ b/faster_sam/lambda_event.py
@@ -116,7 +116,7 @@ class SQS(ResourceInterface):
         except Exception:
             return CustomResponse({"body": "Error processing message", "statusCode": 500})
 
-        if "batchItemFailures" in result:
+        if isinstance(result, dict) and "batchItemFailures" in result:
             return CustomResponse({"body": json.dumps(result), "statusCode": 500})
 
         return CustomResponse({"body": json.dumps(result), "statusCode": 200})


### PR DESCRIPTION
### Contain
- [ ] New feature
- [x] Bugfix
- [ ] Tests
- [ ] Documentation
- [ ] Build/CI/CD
- [ ] Breaking changes
- [ ] Refactor
- [ ] Configuration changes
- [ ] Migrations

### Details
* Fix cases where return from sqs is null
