### PR TITLE
refactor: split enum in cloudformation module

### DIFF
--- a/faster_sam/adapter.py
+++ b/faster_sam/adapter.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 
 from fastapi import FastAPI
 
-from faster_sam.cloudformation import CloudformationTemplate, NodeType
+from faster_sam.cloudformation import CloudformationTemplate, EventType
 from faster_sam.openapi import custom_openapi
 from faster_sam.routing import APIRoute, QueueRoute, ScheduleRoute
 
@@ -39,7 +39,9 @@ class SAM:
     """
 
     def __init__(
-        self, template_path: Optional[str] = None, parameters: Optional[Dict[str, str]] = None
+        self,
+        template_path: Optional[str] = None,
+        parameters: Optional[Dict[str, str]] = None,
     ) -> None:
         """
         Initializes the SAM object.
@@ -212,7 +214,7 @@ class SAM:
             if "Events" not in function["Properties"]:
                 continue
 
-            events = self.template.find_nodes(function["Properties"]["Events"], NodeType.SQS_EVENT)
+            events = self.template.find_nodes(function["Properties"]["Events"], EventType.SQS)
 
             for event in events.values():
                 handler_path = self.template.lambda_handler(resource_id)
@@ -248,9 +250,7 @@ class SAM:
             if "Events" not in function["Properties"]:
                 continue
 
-            events = self.template.find_nodes(
-                function["Properties"]["Events"], NodeType.SCHEDULER_EVENT
-            )
+            events = self.template.find_nodes(function["Properties"]["Events"], EventType.SCHEDULER)
 
             if not events:
                 continue
@@ -288,7 +288,7 @@ class SAM:
                 continue
 
             handler_path = self.template.lambda_handler(resource_id)
-            events = self.template.find_nodes(function["Properties"]["Events"], NodeType.API_EVENT)
+            events = self.template.find_nodes(function["Properties"]["Events"], EventType.API)
 
             for event in events.values():
                 rest_api_id = event["Properties"].get("RestApiId", {"Ref": None})["Ref"]

--- a/tests/test_cloudformation.py
+++ b/tests/test_cloudformation.py
@@ -159,7 +159,8 @@ class TestCloudformationTemplate(unittest.TestCase):
         )
 
         self.assertEqual(
-            cloudformation.template["Parameters"]["Environment"]["Default"], "development"
+            cloudformation.template["Parameters"]["Environment"]["Default"],
+            "development",
         )
 
     def test_load_raises_exception(self):
@@ -224,7 +225,7 @@ class TestCloudformationTemplate(unittest.TestCase):
     def test_find_nodes(self):
         cloudformation = CloudformationTemplate("tests/fixtures/templates/example1.yml")
         tree = cloudformation.template
-        nodes = cloudformation.find_nodes(tree["Resources"], cf.NodeType.LAMBDA)
+        nodes = cloudformation.find_nodes(tree["Resources"], cf.ResourceType.FUNCTION)
 
         self.assertEqual(nodes, self.functions)
 


### PR DESCRIPTION
### Contain
- [x] Refactor

### Details
- Separate resources from events when defining enum values
- Sort imports
