### PR TITLE
feat: add aws cloudformation class definiton for api event source

### DIFF
--- a/faster_sam/cloudformation.py
+++ b/faster_sam/cloudformation.py
@@ -164,7 +164,29 @@ class EventSource(Resource):
 
     @classmethod
     def from_resource(cls, resource_id: str, resource: Dict[str, Any]) -> "EventSource":
+        if resource["Type"] == EventType.API.value:
+            return ApiEvent(resource_id, resource)
+
         return cls(resource_id, resource)
+
+
+class ApiEvent(EventSource):
+    @property
+    def path(self):
+        return self.resource["Properties"]["Path"]
+
+    @property
+    def method(self):
+        return self.resource["Properties"]["Method"]
+
+    @property
+    def rest_api_id(self):
+        resource_id = self.resource["Properties"]["RestApiId"]
+
+        if isinstance(resource_id, dict):
+            resource_id = resource_id["Ref"]
+
+        return resource_id
 
 
 class Function(Resource):
@@ -275,6 +297,7 @@ class CloudformationTemplate:
 
         if not hasattr(self, "_functions"):
             self._functions = self.find_nodes(self.template["Resources"], ResourceType.FUNCTION)
+
         return self._functions
 
     @property
@@ -319,6 +342,7 @@ class CloudformationTemplate:
 
         if not hasattr(self, "_environment"):
             self._environment = self.find_environment()
+
         return self._environment
 
     def include_files(self):
@@ -461,10 +485,12 @@ class CloudformationTemplate:
         Returns a string representing the full module path for a Lambda Function handler.
         The path is built by joining the code URI and the handler attributes on
         the CloudFormation for the given Lambda Function identified by resource_id.
+
         Parameters
         ----------
         resource_id : str
             The id of the Lambda function resource.
+
         Returns
         -------
         str

--- a/tests/test_cloudformation.py
+++ b/tests/test_cloudformation.py
@@ -324,3 +324,23 @@ class TestFunction(unittest.TestCase):
         for event in instance.filtered_events(cf.EventType.API).values():
             with self.subTest(event=event):
                 self.assertEqual(event.type, cf.EventType.API)
+
+
+class TestApiEvent(unittest.TestCase):
+    def test_api_event(self):
+        resource_id = "TestApi"
+        resource = {
+            "Type": "Api",
+            "Properties": {
+                "RestApiId": {"Ref": "ApiGateway"},
+                "Path": "/test",
+                "Method": "get",
+            },
+        }
+
+        instance = cf.ApiEvent(resource_id, resource)
+
+        self.assertEqual(instance.rest_api_id, "ApiGateway")
+        self.assertEqual(instance.path, "/test")
+        self.assertEqual(instance.method, "get")
+        self.assertEqual(instance.type, cf.EventType.API)


### PR DESCRIPTION
### Contain
- [x] New feature
- [x] Tests

### Details
* Add AWS CloudFormation class definition for Api event sources.
