### PR TITLE
feat: return instance of queues instead of dictionary on cf propety

### DIFF
--- a/faster_sam/adapter.py
+++ b/faster_sam/adapter.py
@@ -226,7 +226,7 @@ class SAM:
                     resource_arn = resource_arn[0]
 
                 resource_name = resource_arn.replace(".Arn", "")
-                queue_name = self.template.queues[resource_name]["Properties"]["QueueName"]
+                queue_name = self.template.queues[resource_name].name
 
                 path = f"/{queue_name}"
                 endpoint = {"POST": {"handler": handler_path}}

--- a/faster_sam/adapter.py
+++ b/faster_sam/adapter.py
@@ -211,10 +211,12 @@ class SAM:
         routes: Dict[str, Any] = {}
 
         for resource_id, function in self.template.functions.items():
-            if "Events" not in function["Properties"]:
+            if "Events" not in function.resource["Properties"]:
                 continue
 
-            events = self.template.find_nodes(function["Properties"]["Events"], EventType.SQS)
+            events = self.template.find_nodes(
+                function.resource["Properties"]["Events"], EventType.SQS
+            )
 
             for event in events.values():
                 handler_path = self.template.lambda_handler(resource_id)
@@ -247,15 +249,17 @@ class SAM:
         routes: Dict[str, Any] = {}
 
         for resource_id, function in self.template.functions.items():
-            if "Events" not in function["Properties"]:
+            if "Events" not in function.resource["Properties"]:
                 continue
 
-            events = self.template.find_nodes(function["Properties"]["Events"], EventType.SCHEDULE)
+            events = self.template.find_nodes(
+                function.resource["Properties"]["Events"], EventType.SCHEDULE
+            )
 
             if not events:
                 continue
 
-            function_name = function["Properties"]["FunctionName"].replace("_", "-")
+            function_name = function.resource["Properties"]["FunctionName"].replace("_", "-")
             handler_path = self.template.lambda_handler(resource_id)
 
             path = f"/{function_name}"
@@ -284,11 +288,13 @@ class SAM:
         routes: Dict[str, Any] = {}
 
         for resource_id, function in self.template.functions.items():
-            if "Events" not in function["Properties"]:
+            if "Events" not in function.resource["Properties"]:
                 continue
 
             handler_path = self.template.lambda_handler(resource_id)
-            events = self.template.find_nodes(function["Properties"]["Events"], EventType.API)
+            events = self.template.find_nodes(
+                function.resource["Properties"]["Events"], EventType.API
+            )
 
             for event in events.values():
                 rest_api_id = event["Properties"].get("RestApiId", {"Ref": None})["Ref"]

--- a/faster_sam/adapter.py
+++ b/faster_sam/adapter.py
@@ -250,7 +250,7 @@ class SAM:
             if "Events" not in function["Properties"]:
                 continue
 
-            events = self.template.find_nodes(function["Properties"]["Events"], EventType.SCHEDULER)
+            events = self.template.find_nodes(function["Properties"]["Events"], EventType.SCHEDULE)
 
             if not events:
                 continue

--- a/faster_sam/cloudformation.py
+++ b/faster_sam/cloudformation.py
@@ -189,6 +189,16 @@ class ApiEvent(EventSource):
         return resource_id
 
 
+class SQSEvent(EventSource):
+    @property
+    def queue(self) -> str:
+        return self.resource["Properties"]["Queue"]
+
+    @property
+    def batch_size(self) -> int:
+        return self.resource["Properties"]["BatchSize"]
+
+
 class Function(Resource):
     @property
     def name(self) -> str:

--- a/faster_sam/cloudformation.py
+++ b/faster_sam/cloudformation.py
@@ -377,9 +377,11 @@ class CloudformationTemplate:
         Dict[str, Any]:
             Dictionary containing SQS Queue resources in the CloudFormation template.
         """
-
         if not hasattr(self, "_queues"):
-            self._queues = self.find_nodes(self.template["Resources"], ResourceType.QUEUE)
+            self._queues = {}
+            nodes = self.find_nodes(self.template["Resources"], ResourceType.QUEUE)
+            for resource_id, resource in nodes.items():
+                self._queues[resource_id] = Queue(resource_id, resource)
         return self._queues
 
     @property

--- a/faster_sam/cloudformation.py
+++ b/faster_sam/cloudformation.py
@@ -267,6 +267,16 @@ class Function(Resource):
         return events
 
 
+class Api(Resource):
+    @property
+    def name(self) -> str:
+        return self.resource["Properties"]["Name"]
+
+    @property
+    def stage_name(self) -> str:
+        return self.resource["Properties"]["StageName"]
+
+
 class Queue(Resource):
     @property
     def name(self) -> str:

--- a/faster_sam/cloudformation.py
+++ b/faster_sam/cloudformation.py
@@ -372,9 +372,9 @@ class CloudformationTemplate:
         return self._gateways
 
     @property
-    def queues(self) -> Dict[str, Any]:
+    def queues(self) -> Dict[str, Queue]:
         """
-        Dict[str, Any]:
+        Dict[str, Queue]:
             Dictionary containing SQS Queue resources in the CloudFormation template.
         """
         if not hasattr(self, "_queues"):

--- a/faster_sam/cloudformation.py
+++ b/faster_sam/cloudformation.py
@@ -199,6 +199,12 @@ class SQSEvent(EventSource):
         return self.resource["Properties"]["BatchSize"]
 
 
+class ScheduleEvent(EventSource):
+    @property
+    def schedule(self) -> str:
+        return self.resource["Properties"]["Schedule"]
+
+
 class Function(Resource):
     @property
     def name(self) -> str:

--- a/faster_sam/cloudformation.py
+++ b/faster_sam/cloudformation.py
@@ -68,13 +68,13 @@ class EventType(Enum):
         Represents the "Api" node type.
     SQS : str
         Represents the "SQS" node type.
-    SCHEDULER : str
+    SCHEDULE : str
         Represents the "Schedule" node type.
     """
 
     API = "Api"
     SQS = "SQS"
-    SCHEDULER = "Schedule"
+    SCHEDULE = "Schedule"
 
 
 def multi_constructor(loader: CFLoader, tag_suffix: str, node: yaml.nodes.Node) -> Dict[str, Any]:

--- a/faster_sam/cloudformation.py
+++ b/faster_sam/cloudformation.py
@@ -285,6 +285,12 @@ class Queue(Resource):
         return self.resource["Properties"]["RedrivePolicy"]
 
 
+class Bucket(Resource):
+    @property
+    def name(self) -> str:
+        return self.resource["Properties"]["BucketName"]
+
+
 class CloudformationTemplate:
     """
     Represents an AWS CloudFormation template and provides methods for

--- a/faster_sam/cloudformation.py
+++ b/faster_sam/cloudformation.py
@@ -164,10 +164,16 @@ class EventSource(Resource):
 
     @classmethod
     def from_resource(cls, resource_id: str, resource: Dict[str, Any]) -> "EventSource":
-        if resource["Type"] == EventType.API.value:
-            return ApiEvent(resource_id, resource)
+        event_sources = {
+            EventType.API: ApiEvent,
+            EventType.SQS: SQSEvent,
+            EventType.SCHEDULE: ScheduleEvent,
+        }
 
-        return cls(resource_id, resource)
+        event_type = EventType(resource["Type"])
+        event_source = event_sources.get(event_type, cls)
+
+        return event_source(resource_id, resource)
 
 
 class ApiEvent(EventSource):

--- a/faster_sam/cloudformation.py
+++ b/faster_sam/cloudformation.py
@@ -380,8 +380,10 @@ class CloudformationTemplate:
         if not hasattr(self, "_queues"):
             self._queues = {}
             nodes = self.find_nodes(self.template["Resources"], ResourceType.QUEUE)
+
             for resource_id, resource in nodes.items():
                 self._queues[resource_id] = Queue(resource_id, resource)
+
         return self._queues
 
     @property

--- a/faster_sam/cmd/faster.py
+++ b/faster_sam/cmd/faster.py
@@ -25,7 +25,7 @@ def resource_list(args: argparse.Namespace) -> None:
     if args.type is not None:
         resources = getattr(cf, args.type)
 
-        if args.type == "functions":
+        if args.type in ("functions", "queues"):
             resources = {key: value.resource for key, value in resources.items()}
 
     if resources:

--- a/faster_sam/cmd/faster.py
+++ b/faster_sam/cmd/faster.py
@@ -25,6 +25,9 @@ def resource_list(args: argparse.Namespace) -> None:
     if args.type is not None:
         resources = getattr(cf, args.type)
 
+        if args.type == "functions":
+            resources = {key: value.resource for key, value in resources.items()}
+
     if resources:
         formatter = formatters[OutputFormat(args.output)]
         print(formatter(resources))

--- a/faster_sam/cmd/faster.py
+++ b/faster_sam/cmd/faster.py
@@ -27,7 +27,7 @@ def resource_list(args: argparse.Namespace) -> None:
 
         if args.type in ("functions", "buckets", "queues"):
             resources = {key: value.resource for key, value in resources.items()}
-            
+
     if resources:
         formatter = formatters[OutputFormat(args.output)]
         print(formatter(resources))

--- a/tests/test_cloudformation.py
+++ b/tests/test_cloudformation.py
@@ -374,3 +374,21 @@ class TestQueue(unittest.TestCase):
                 "maxReceiveCount": 3,
             },
         )
+
+
+class TestSQSEvent(unittest.TestCase):
+    def test_sqs_event(self):
+        resource_id = "TestSQS"
+        resource = {
+            "Type": "SQS",
+            "Properties": {
+                "Queue": "arn:aws:sqs:us-west-2::test-queue",
+                "BatchSize": 10,
+            },
+        }
+
+        instance = cf.SQSEvent(resource_id, resource)
+
+        self.assertEqual(instance.queue, "arn:aws:sqs:us-west-2::test-queue")
+        self.assertEqual(instance.batch_size, 10)
+        self.assertEqual(instance.type, cf.EventType.SQS)

--- a/tests/test_cloudformation.py
+++ b/tests/test_cloudformation.py
@@ -173,7 +173,9 @@ class TestCloudformationTemplate(unittest.TestCase):
     def test_list_functions(self):
         cloudformation = CloudformationTemplate(self.template_1)
 
-        self.assertEqual(cloudformation.functions, self.functions)
+        for function in cloudformation.functions.values():
+            with self.subTest(function=function.resource):
+                self.assertEqual(function.resource, self.functions[function.id])
 
     def test_list_gateways(self):
         cloudformation = CloudformationTemplate("tests/fixtures/templates/example2.yml")

--- a/tests/test_cloudformation.py
+++ b/tests/test_cloudformation.py
@@ -376,6 +376,22 @@ class TestQueue(unittest.TestCase):
         )
 
 
+class TestBucket(unittest.TestCase):
+    def test_bucket(self):
+        resource_id = "TestBucket"
+        resource = {
+            "Type": "AWS::S3::Bucket",
+            "DeletionPolicy": "Retain",
+            "Properties": {
+                "BucketName": "test-bucket",
+            },
+        }
+
+        instance = cf.Bucket(resource_id, resource)
+
+        self.assertEqual(instance.name, "test-bucket")
+
+
 class TestSQSEvent(unittest.TestCase):
     def test_sqs_event(self):
         resource_id = "TestSQS"

--- a/tests/test_cloudformation.py
+++ b/tests/test_cloudformation.py
@@ -433,3 +433,19 @@ class TestSQSEvent(unittest.TestCase):
         self.assertEqual(instance.queue, "arn:aws:sqs:us-west-2::test-queue")
         self.assertEqual(instance.batch_size, 10)
         self.assertEqual(instance.type, cf.EventType.SQS)
+
+
+class TestScheduleEvent(unittest.TestCase):
+    def test_schedule_event(self):
+        resource_id = "TestSchedule"
+        resource = {
+            "Type": "Schedule",
+            "Properties": {
+                "Schedule": "rate(1 minute)",
+            },
+        }
+
+        instance = cf.ScheduleEvent(resource_id, resource)
+
+        self.assertEqual(instance.schedule, "rate(1 minute)")
+        self.assertEqual(instance.type, cf.EventType.SCHEDULE)

--- a/tests/test_cloudformation.py
+++ b/tests/test_cloudformation.py
@@ -185,7 +185,9 @@ class TestCloudformationTemplate(unittest.TestCase):
     def test_list_queues(self):
         cloudformation = CloudformationTemplate("tests/fixtures/templates/example6.yml")
 
-        self.assertEqual(cloudformation.queues, self.queues)
+        for queue in cloudformation.queues.values():
+            with self.subTest(queue=queue.resource):
+                self.assertEqual(queue.resource, self.queues[queue.id])
 
     def test_list_buckets(self):
         buckets = {

--- a/tests/test_cloudformation.py
+++ b/tests/test_cloudformation.py
@@ -326,6 +326,31 @@ class TestFunction(unittest.TestCase):
                 self.assertEqual(event.type, cf.EventType.API)
 
 
+class TestApi(unittest.TestCase):
+    def test_api(self):
+        resource_id = "ApiGateway"
+        resource = {
+            "Type": "AWS::Serverless::Api",
+            "Properties": {
+                "Name": "api",
+                "StageName": "v1",
+                "DefinitionBody": {
+                    "Fn::Transform": {
+                        "Name": "AWS::Include",
+                        "Parameters": {
+                            "Location": "./swagger.yml",
+                        },
+                    },
+                },
+            },
+        }
+
+        instance = cf.Api(resource_id, resource)
+
+        self.assertEqual(instance.name, "api")
+        self.assertEqual(instance.stage_name, "v1")
+
+
 class TestApiEvent(unittest.TestCase):
     def test_api_event(self):
         resource_id = "TestApi"


### PR DESCRIPTION
### Contain
- [x] New feature
- [x] Tests
- [x] Refactor

### Details
* Update CloudFormation property queues returning a dictionary of instances instead of pure dictionaries.
