### PR TITLE
feat: return instance of api instead of dictionary on cf propety

### DIFF
--- a/faster_sam/adapter.py
+++ b/faster_sam/adapter.py
@@ -81,9 +81,9 @@ class SAM:
         gateway: Dict[str, Any] = {"Properties": {}}
 
         if gateway_id is not None:
-            gateway = self.template.gateways[gateway_id]
+            gateway = self.template.apis[gateway_id].resource
         else:
-            gateway_ids = list(self.template.gateways.keys())
+            gateway_ids = list(self.template.apis.keys())
             gateway_len = len(gateway_ids)
 
             if gateway_len > 1:
@@ -92,8 +92,9 @@ class SAM:
 
             if gateway_len == 1:
                 gateway_id = gateway_ids[0]
-                gateway = self.template.gateways[gateway_id]
+                gateway = self.template.apis[gateway_id].resource
 
+        # TODO: change to use definition body attribute when available
         openapi_schema = gateway["Properties"].get("DefinitionBody")
 
         if openapi_schema is None:

--- a/faster_sam/cmd/faster.py
+++ b/faster_sam/cmd/faster.py
@@ -24,9 +24,7 @@ def resource_list(args: argparse.Namespace) -> None:
 
     if args.type is not None:
         resources = getattr(cf, args.type)
-
-        if args.type in ("functions", "buckets", "queues"):
-            resources = {key: value.resource for key, value in resources.items()}
+        resources = {key: value.resource for key, value in resources.items()}
 
     if resources:
         formatter = formatters[OutputFormat(args.output)]
@@ -51,7 +49,7 @@ def main() -> None:
     rsc_list_parser.add_argument(
         "-t",
         "--type",
-        choices=["buckets", "functions", "gateways", "queues"],
+        choices=["apis", "buckets", "functions", "queues"],
         help="filter by resource type. accepted values: %(choices)s.",
     )
     rsc_list_parser.add_argument(

--- a/tests/test_cloudformation.py
+++ b/tests/test_cloudformation.py
@@ -180,7 +180,9 @@ class TestCloudformationTemplate(unittest.TestCase):
     def test_list_gateways(self):
         cloudformation = CloudformationTemplate("tests/fixtures/templates/example2.yml")
 
-        self.assertEqual(cloudformation.gateways, self.gateways)
+        for api in cloudformation.apis.values():
+            with self.subTest(api=api.resource):
+                self.assertEqual(api.resource, self.gateways[api.id])
 
     def test_list_queues(self):
         cloudformation = CloudformationTemplate("tests/fixtures/templates/example6.yml")


### PR DESCRIPTION
### Contain
- [x] New feature
- [x] Tests
- [x] Refactor

### Details
* Update CloudFormation template class property `gateways` renaming to `apis` and changing its returning type from pure dictionary to a dictionary of instances.
