### PR TITLE
refactor: adjust message attributes adding stringValue

### DIFF
--- a/faster_sam/dependencies/events.py
+++ b/faster_sam/dependencies/events.py
@@ -56,7 +56,7 @@ def sqs(schema: Type[BaseModel]) -> Callable[[BaseModel], Dict[str, Any]]:
                         "SenderId": str(uuid.uuid4()),
                         "ApproximateFirstReceiveTimestamp": info.sent_timestamp,
                     },
-                    "messageAttributes": info.message_attributes,
+                    "messageAttributes": {"stringValue": info.message_attributes, **info.message_attributes},
                     "md5OfBody": hashlib.md5(info.body.encode()).hexdigest(),
                     "eventSource": "aws:sqs",
                     "eventSourceARN": info.source_arn,


### PR DESCRIPTION
### Contain
- [x] Bugfix
- [x] Refactor


### Details
* When sending events to Google Cloud Pub/Sub, message attributes were expected to include a _stringValue_, but the current implementation was sending only a plain string. This caused processing errors. I updated the fastersam handler to ensure _messageAttributes_ now includes stringValue, which resolves the issue and allows Pub/Sub to correctly handle the attributes.
