### PR TITLE
Add Helpers build_messages_attributes

### DIFF
--- a/faster_sam/dependencies/events.py
+++ b/faster_sam/dependencies/events.py
@@ -4,7 +4,7 @@ import json
 from typing import Any, Callable, Dict, Type
 from uuid import uuid4
 import uuid
-from dependencies.helpers import build_messages_attributes
+from faster_sam.dependencies.helpers import build_messages_attributes
 
 from fastapi import Request
 from pydantic import BaseModel

--- a/faster_sam/dependencies/events.py
+++ b/faster_sam/dependencies/events.py
@@ -56,7 +56,10 @@ def sqs(schema: Type[BaseModel]) -> Callable[[BaseModel], Dict[str, Any]]:
                         "SenderId": str(uuid.uuid4()),
                         "ApproximateFirstReceiveTimestamp": info.sent_timestamp,
                     },
-                    "messageAttributes": info.message_attributes,
+                    "messageAttributes": {
+                        "stringValue": info.message_attributes,
+                        **info.message_attributes,
+                    },
                     "md5OfBody": hashlib.md5(info.body.encode()).hexdigest(),
                     "eventSource": "aws:sqs",
                     "eventSourceARN": info.source_arn,

--- a/faster_sam/dependencies/events.py
+++ b/faster_sam/dependencies/events.py
@@ -57,7 +57,10 @@ def sqs(schema: Type[BaseModel]) -> Callable[[BaseModel], Dict[str, Any]]:
                         "ApproximateFirstReceiveTimestamp": info.sent_timestamp,
                     },
                     "messageAttributes": {
-                        "stringValue": info.message_attributes,
+                        **{
+                            key: {"stringValue": value}
+                            for key, value in info.message_attributes.items()
+                        },
                         **info.message_attributes,
                     },
                     "md5OfBody": hashlib.md5(info.body.encode()).hexdigest(),

--- a/faster_sam/dependencies/events.py
+++ b/faster_sam/dependencies/events.py
@@ -47,7 +47,7 @@ def sqs(schema: Type[BaseModel]) -> Callable[[BaseModel], Dict[str, Any]]:
         info = message.into()
 
         message_attributes = {}
-        if not info.message_attributes:
+        if info.message_attributes:
             message_attributes = helpers.build_message_attributes(info.message_attributes)
 
         event = {

--- a/faster_sam/dependencies/events.py
+++ b/faster_sam/dependencies/events.py
@@ -4,7 +4,7 @@ import json
 from typing import Any, Callable, Dict, Type
 from uuid import uuid4
 import uuid
-from faster_sam.dependencies.helpers import build_messages_attributes
+from faster_sam import helpers
 
 from fastapi import Request
 from pydantic import BaseModel
@@ -45,7 +45,11 @@ def sqs(schema: Type[BaseModel]) -> Callable[[BaseModel], Dict[str, Any]]:
         assert isinstance(message, IntoSQSInfo)
 
         info = message.into()
-        message_attributes = build_messages_attributes(info.message_attributes)
+
+        message_attributes = {}
+        if not info.message_attributes:
+            message_attributes = helpers.build_message_attributes(info.message_attributes)
+
         event = {
             "Records": [
                 {

--- a/faster_sam/dependencies/helpers.py
+++ b/faster_sam/dependencies/helpers.py
@@ -1,4 +1,7 @@
 def build_messages_attributes(attributes: dict[str, str]) -> dict[str, dict[str, str]]:
+    if not attributes:
+        return {}
+
     attrs = {}
 
     for key, value in attributes.items():

--- a/faster_sam/dependencies/helpers.py
+++ b/faster_sam/dependencies/helpers.py
@@ -1,0 +1,12 @@
+def build_messages_attributes(attributes: dict[str, str]) -> dict[str, dict[str, str]]:
+    attrs = {}
+
+    for key, value in attributes.items():
+        if isinstance(value, str):
+            attrs[key] = {"stringValue": value, "dataType": "String"}
+        elif isinstance(value, (int, float)):
+            attrs[key] = {"stringValue": str(value), "dataType": "Number"}
+        else:
+            raise TypeError(f"{value} of type {type(value).__name__} is not supported")
+
+    return attrs

--- a/faster_sam/helpers.py
+++ b/faster_sam/helpers.py
@@ -1,7 +1,7 @@
-def build_messages_attributes(attributes: dict[str, str]) -> dict[str, dict[str, str]]:
-    if not attributes:
-        return {}
+from typing import Dict
 
+
+def build_message_attributes(attributes: Dict[str, str]) -> Dict[str, Dict[str, str]]:
     attrs = {}
 
     for key, value in attributes.items():
@@ -9,6 +9,8 @@ def build_messages_attributes(attributes: dict[str, str]) -> dict[str, dict[str,
             attrs[key] = {"stringValue": value, "dataType": "String"}
         elif isinstance(value, (int, float)):
             attrs[key] = {"stringValue": str(value), "dataType": "Number"}
+        elif isinstance(value, bytes):
+            attrs[key] = {"BinaryValue": str(value), "dataType": "Binary"}
         else:
             raise TypeError(f"{value} of type {type(value).__name__} is not supported")
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,41 @@
+import unittest
+from faster_sam.dependencies.helpers import build_messages_attributes
+
+
+class TestHelpers(unittest.TestCase):
+
+    def teste_empty_attributes(self):
+        result = build_messages_attributes({})
+        self.assertEqual(result, {})
+
+    def test_string_attributes(self):
+        attributes = {"key1": "value1", "key2": "value2"}
+        expected_result = {
+            "key1": {"stringValue": "value1", "dataType": "String"},
+            "key2": {"stringValue": "value2", "dataType": "String"},
+        }
+        result = build_messages_attributes(attributes)
+        self.assertEqual(result, expected_result)
+
+    def test_number_attributes(self):
+        attributes = {"key1": 123, "key2": 12.3}
+        expected_result = {
+            "key1": {"stringValue": "123", "dataType": "Number"},
+            "key2": {"stringValue": "12.3", "dataType": "Number"},
+        }
+        result = build_messages_attributes(attributes)
+        self.assertEqual(result, expected_result)
+
+    def test_multi_attributes(self):
+        attributes = {"key1": 123, "key2": "value1"}
+        expected_result = {
+            "key1": {"stringValue": "123", "dataType": "Number"},
+            "key2": {"stringValue": "value1", "dataType": "String"},
+        }
+        result = build_messages_attributes(attributes)
+        self.assertEqual(result, expected_result)
+
+    def test_unsupported_type(self):
+        attributes = {"key1": "value1", "key2": [1, 2, 3]}
+        with self.assertRaises(TypeError):
+            build_messages_attributes(attributes)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,11 +1,11 @@
 import unittest
-from faster_sam.dependencies.helpers import build_messages_attributes
+
+from faster_sam import helpers
 
 
 class TestHelpers(unittest.TestCase):
-
     def teste_empty_attributes(self):
-        result = build_messages_attributes({})
+        result = helpers.build_message_attributes({})
         self.assertEqual(result, {})
 
     def test_string_attributes(self):
@@ -14,7 +14,7 @@ class TestHelpers(unittest.TestCase):
             "key1": {"stringValue": "value1", "dataType": "String"},
             "key2": {"stringValue": "value2", "dataType": "String"},
         }
-        result = build_messages_attributes(attributes)
+        result = helpers.build_message_attributes(attributes)
         self.assertEqual(result, expected_result)
 
     def test_number_attributes(self):
@@ -23,7 +23,13 @@ class TestHelpers(unittest.TestCase):
             "key1": {"stringValue": "123", "dataType": "Number"},
             "key2": {"stringValue": "12.3", "dataType": "Number"},
         }
-        result = build_messages_attributes(attributes)
+        result = helpers.build_message_attributes(attributes)
+        self.assertEqual(result, expected_result)
+
+    def test_bytes_attributes(self):
+        attributes = {"key1": b"test_bytes"}
+        expected_result = {"key1": {"BinaryValue": str(b"test_bytes"), "dataType": "Binary"}}
+        result = helpers.build_message_attributes(attributes)
         self.assertEqual(result, expected_result)
 
     def test_multi_attributes(self):
@@ -32,10 +38,10 @@ class TestHelpers(unittest.TestCase):
             "key1": {"stringValue": "123", "dataType": "Number"},
             "key2": {"stringValue": "value1", "dataType": "String"},
         }
-        result = build_messages_attributes(attributes)
+        result = helpers.build_message_attributes(attributes)
         self.assertEqual(result, expected_result)
 
     def test_unsupported_type(self):
         attributes = {"key1": "value1", "key2": [1, 2, 3]}
         with self.assertRaises(TypeError):
-            build_messages_attributes(attributes)
+            helpers.build_message_attributes(attributes)


### PR DESCRIPTION
### Contain
- [x] New feature
- [x] Tests

### Details
* Add Modules Helpers  containing the build_messages_attributes function, which is responsible for standardizing and handling message attributes sent to Pub/Sub.
* Add unittest to cover following scenarios, (Empty attributes, String attributes, Numeric attributes (int and fload), combination os string and number, and handling unsupported types (raises TypeError).
